### PR TITLE
style fixes

### DIFF
--- a/battery-status-collect
+++ b/battery-status-collect
@@ -24,24 +24,23 @@ if [ ! -e "$logfile" ] ; then
 fi
 
 log_battery() {
-    # Print complete message in one echo call, to avoid race condition
-    # when several log processes run in parallel.
-    msg=$(printf "%s," $(date +%s); \
-	for f in $files; do \
-	    for file in $(echo $f | tr / " "); do
-	        if [ -e $file ] ; then fexist=$file; fi ; \
-	    done ; \
-	    if [ -e "$fexist" ] ; then \
-		printf "%s," $(cat $fexist); \
-	    else \
-		printf "," ; \
-	    fi \
-	done)
-    echo "$msg"
+    printf "%s," $(date +%s)
+    for f in $files; do 
+	for file in $(echo $f | tr / " "); do
+	    if [ -e $file ] ; then fexist=$file; fi
+	done
+	if [ -e "$fexist" ] ; then
+	    printf "%s," $(cat $fexist)
+	else
+	    printf ","
+	fi
+    done
 }
 
 cd /sys/class/power_supply
 
 for bat in BAT*; do
-    (cd $bat && log_battery >> "$logfile")
+    # Print complete message in one echo call, to avoid race condition
+    # when several log processes run in parallel.
+    (cd $bat && echo $(log_battery)) >> "$logfile"
 done

--- a/battery-status-graph
+++ b/battery-status-graph
@@ -8,20 +8,25 @@ filename="${1}"
 type=$(head -2 "$input" | tail -1 | cut -d, -f2-4 | tr , " ")
 
 (
-    echo set xdata time
-    echo set timefmt \"%s\"
-    echo set format x \"%Y\"
-    echo set datafile separator \",\"
-    echo set title \'Battery statistics $type\'
-    echo set ylabel \'Percent\'
-    echo set xlabel \'Year\'
-    echo set grid
+    cat <<EOF
+set xdata time
+set timefmt "%s"
+set format x "%Y"
+set datafile separator ","
+set title 'Battery statistics $type'
+set ylabel 'Percent'
+set xlabel 'Year'
+set grid
+EOF
     if [ "$filename" ]; then
-        echo set term png
-        echo set output \"$filename\"
+        cat <<EOF
+set term png
+set output "$filename"
+EOF
     fi
-    echo plot "\"$input\" using 1:(100 * \$8 / \$7) smooth unique axis x1y1 title \"Battery level %\" with lines linewidth 0.1 linecolor rgb 'grey',\"$input\" using 1:(100 * \$6 / \$7) smooth unique axis x1y1 title \"Battery full capacity %\" with lines linewidth 1 linecolor rgb 'red',\"$input\" using 1:(100 * \$7 / \$7) smooth unique axis x1y1 title \"Battery design capacity %\" with lines linewidth 1 linecolor rgb 'black'"
-
+    cat <<EOF
+plot "$input" using 1:(100 * \$8 / \$7) smooth unique axis x1y1 title "Battery level %" with lines linewidth 0.1 linecolor rgb 'grey',"$input" using 1:(100 * \$6 / \$7) smooth unique axis x1y1 title "Battery full capacity %" with lines linewidth 1 linecolor rgb 'red',"$input" using 1:(100 * \$7 / \$7) smooth unique axis x1y1 title "Battery design capacity %" with lines linewidth 1 linecolor rgb 'black'
+EOF
 ) | gnuplot -p
 
 if [ "$filename" ] ; then

--- a/battery-status-graph
+++ b/battery-status-graph
@@ -25,7 +25,13 @@ set output "$filename"
 EOF
     fi
     cat <<EOF
-plot "$input" using 1:(100 * \$8 / \$7) smooth unique axis x1y1 title "Battery level %" with lines linewidth 0.1 linecolor rgb 'grey',"$input" using 1:(100 * \$6 / \$7) smooth unique axis x1y1 title "Battery full capacity %" with lines linewidth 1 linecolor rgb 'red',"$input" using 1:(100 * \$7 / \$7) smooth unique axis x1y1 title "Battery design capacity %" with lines linewidth 1 linecolor rgb 'black'
+plot "$input" using 1:(100 * \$8 / \$7) \
+  smooth unique axis x1y1 title "Battery level %" \
+    with lines linewidth 0.1 linecolor rgb 'grey',"$input" using 1:(100 * \$6 / \$7) \
+  smooth unique axis x1y1 title "Battery full capacity %" \
+    with lines linewidth 1 linecolor rgb 'red',"$input" using 1:(100 * \$7 / \$7) \
+  smooth unique axis x1y1 title "Battery design capacity %" \
+    with lines linewidth 1 linecolor rgb 'black'
 EOF
 ) | gnuplot -p
 


### PR DESCRIPTION
instead of making that function a one-liner, we put it back to
multiple lines and instead wrap it in a echo call to work around the
race condition from the outside.

i haven't found such race conditions so far, so i am not clear on how
to reproduce this, but it should still work while making the code
cleaner.

At the very least, this doesn't seem to have problems:

```
./battery-status-collect & ./battery-status-collect
```
