### PR TITLE
make format of the dates more granular

### DIFF
--- a/battery-status-collect
+++ b/battery-status-collect
@@ -24,24 +24,23 @@ if [ ! -e "$logfile" ] ; then
 fi
 
 log_battery() {
-    # Print complete message in one echo call, to avoid race condition
-    # when several log processes run in parallel.
-    msg=$(printf "%s," $(date +%s); \
-	for f in $files; do \
-	    for file in $(echo $f | tr / " "); do
-	        if [ -e $file ] ; then fexist=$file; fi ; \
-	    done ; \
-	    if [ -e "$fexist" ] ; then \
-		printf "%s," $(cat $fexist); \
-	    else \
-		printf "," ; \
-	    fi \
-	done)
-    echo "$msg"
+    printf "%s," $(date +%s)
+    for f in $files; do 
+	for file in $(echo $f | tr / " "); do
+	    if [ -e $file ] ; then fexist=$file; fi
+	done
+	if [ -e "$fexist" ] ; then
+	    printf "%s," $(cat $fexist)
+	else
+	    printf ","
+	fi
+    done
 }
 
 cd /sys/class/power_supply
 
 for bat in BAT*; do
-    (cd $bat && log_battery >> "$logfile")
+    # Print complete message in one echo call, to avoid race condition
+    # when several log processes run in parallel.
+    (cd $bat && echo $(log_battery)) >> "$logfile"
 done

--- a/battery-status-graph
+++ b/battery-status-graph
@@ -9,14 +9,27 @@ type=$(head -2 "$input" | tail -1 | cut -d, -f2-4 | tr , " ")
 
 (
     cat <<EOF
+# autoscale the format of the X axis, inspired by:
+# http://stackoverflow.com/questions/19883155/mixing-date-and-time-on-gnuplot-xaxis
+fmt = "%s"
+stats '$input' using  (strptime(fmt, stringcolumn(1))) nooutput
+t = int(STATS_min)
+t_start = t - tm_hour(t)*60*60 - tm_min(t)*60 - tm_sec(t)
+num_days = 2 + (int(STATS_max) - t)/(24*60*60)
+
 set xdata time
 set timefmt "%s"
-set format x "%Y"
+set format x "%Y-%m-%d"
 set datafile separator ","
 set title 'Battery statistics $type'
 set ylabel 'Percent'
-set xlabel 'Year'
+set xlabel 'Time'
 set grid
+
+set timefmt fmt
+set xtics 4*60*60
+set for [i=0:num_days] xtics add (strftime('%Y-%m-%d', t_start+(i-1)*24*60*60) t_start+(i-1)*24*60*60)
+set format x '%H:%M'
 EOF
     if [ "$filename" ]; then
         cat <<EOF

--- a/battery-status-graph
+++ b/battery-status-graph
@@ -8,20 +8,25 @@ filename="${1}"
 type=$(head -2 "$input" | tail -1 | cut -d, -f2-4 | tr , " ")
 
 (
-    echo set xdata time
-    echo set timefmt \"%s\"
-    echo set format x \"%Y\"
-    echo set datafile separator \",\"
-    echo set title \'Battery statistics $type\'
-    echo set ylabel \'Percent\'
-    echo set xlabel \'Year\'
-    echo set grid
+    cat <<EOF
+set xdata time
+set timefmt "%s"
+set format x "%Y"
+set datafile separator ","
+set title 'Battery statistics $type'
+set ylabel 'Percent'
+set xlabel 'Year'
+set grid
+EOF
     if [ "$filename" ]; then
-        echo set term png
-        echo set output \"$filename\"
+        cat <<EOF
+set term png
+set output "$filename"
+EOF
     fi
-    echo plot "\"$input\" using 1:(100 * \$8 / \$7) smooth unique axis x1y1 title \"Battery level %\" with lines linewidth 0.1 linecolor rgb 'grey',\"$input\" using 1:(100 * \$6 / \$7) smooth unique axis x1y1 title \"Battery full capacity %\" with lines linewidth 1 linecolor rgb 'red',\"$input\" using 1:(100 * \$7 / \$7) smooth unique axis x1y1 title \"Battery design capacity %\" with lines linewidth 1 linecolor rgb 'black'"
-
+    cat <<EOF
+plot "$input" using 1:(100 * \$8 / \$7) smooth unique axis x1y1 title "Battery level %" with lines linewidth 0.1 linecolor rgb 'grey',"$input" using 1:(100 * \$6 / \$7) smooth unique axis x1y1 title "Battery full capacity %" with lines linewidth 1 linecolor rgb 'red',"$input" using 1:(100 * \$7 / \$7) smooth unique axis x1y1 title "Battery design capacity %" with lines linewidth 1 linecolor rgb 'black'
+EOF
 ) | gnuplot -p
 
 if [ "$filename" ] ; then

--- a/battery-status-graph
+++ b/battery-status-graph
@@ -25,7 +25,13 @@ set output "$filename"
 EOF
     fi
     cat <<EOF
-plot "$input" using 1:(100 * \$8 / \$7) smooth unique axis x1y1 title "Battery level %" with lines linewidth 0.1 linecolor rgb 'grey',"$input" using 1:(100 * \$6 / \$7) smooth unique axis x1y1 title "Battery full capacity %" with lines linewidth 1 linecolor rgb 'red',"$input" using 1:(100 * \$7 / \$7) smooth unique axis x1y1 title "Battery design capacity %" with lines linewidth 1 linecolor rgb 'black'
+plot "$input" using 1:(100 * \$8 / \$7) \
+  smooth unique axis x1y1 title "Battery level %" \
+    with lines linewidth 0.1 linecolor rgb 'grey',"$input" using 1:(100 * \$6 / \$7) \
+  smooth unique axis x1y1 title "Battery full capacity %" \
+    with lines linewidth 1 linecolor rgb 'red',"$input" using 1:(100 * \$7 / \$7) \
+  smooth unique axis x1y1 title "Battery design capacity %" \
+    with lines linewidth 1 linecolor rgb 'black'
 EOF
 ) | gnuplot -p
 


### PR DESCRIPTION
this is an experiment: when you first run the graphing script, there
are not many samples available. so everything looks like it's the same
time (e.g. "Year: 2015" for me. this is confusing. the above adds
months and days to the format, but also allows for mixing hours as
well.

this may not scale very well to large datasets. already with my ~24h
dataset, the processing is much much slower (7 seconds instead of ~0
seconds).

it seems to me this is more a limitation of gnuplot than anything... maybe time to pull out R or something...

feel free to close this one... but i felt i should share my work. :)
