### PR TITLE
comment out header line for gnuplot

### DIFF
--- a/battery-status-collect
+++ b/battery-status-collect
@@ -15,7 +15,7 @@ files="manufacturer model_name technology serial_number \
 
 if [ ! -e "$logfile" ] ; then
     (
-	printf "timestamp,"
+	printf "#timestamp,"
 	for f in $files; do
 	    printf "%s," $f
 	done


### PR DESCRIPTION
Without this `#`, gnuplot produces a graph that has no data on it. With it, it produces a graph with lines for battery info.
