### PR TITLE
handle errors in CSV files, various fixes

### DIFF
--- a/battery-status-graph.py
+++ b/battery-status-graph.py
@@ -36,7 +36,7 @@ def parse_csv_np():
     #                    ('energy_now', 'f')])
     return data
 
-def parse_csv(fields = ['timestamp', 'energy_full', 'energy_full_design', 'energy_now']):
+def parse_csv_builtin(fields = ['timestamp', 'energy_full', 'energy_full_design', 'energy_now']):
     import csv
     logging.debug('loading CSV file %s with builtin CSV module', args.logfile)
     log = csv.DictReader(args.logfile)
@@ -49,6 +49,18 @@ def parse_csv(fields = ['timestamp', 'energy_full', 'energy_full_design', 'energ
         logging.warning('CSV file is corrupt, skipping remaining entries: %s', e)
     logging.debug('building data array')
     return np.array(data, dtype=zip(fields, 'f'*len(fields)))
+
+# the builtin CSV parser above is faster, we went from 8 to 2 seconds
+# on our test data here there are probably other ways of making this
+# even faster, see:
+#
+# http://stackoverflow.com/a/25508739/1174784
+# http://softwarerecs.stackexchange.com/a/7510/506
+#
+# TL;DR: performance is currently fine, it could be improved with
+# Numpy.fromfile(), Numpy.load() or pandas.read_csv() which should
+# apparently all outperform the above code by an order of magnitude
+parse_csv = parse_csv_builtin
 
 def to_percent(y, position):
     # Ignore the passed in position. This has the effect of scaling

--- a/battery-status-graph.py
+++ b/battery-status-graph.py
@@ -22,6 +22,7 @@ parser.add_argument('--death', type=int, default=5,
 args = parser.parse_args()
 
 def parse_csv_np():
+    logging.debug('loading CSV file %s with NumPy', args.logfile)
     data = np.genfromtxt(args.logfile,
                          delimiter=',', names=True,
                          filling_values = 0.0)
@@ -37,6 +38,7 @@ def parse_csv_np():
 
 def parse_csv(fields = ['timestamp', 'energy_full', 'energy_full_design', 'energy_now']):
     import csv
+    logging.debug('loading CSV file %s with builtin CSV module', args.logfile)
     log = csv.DictReader(args.logfile)
     data = []
     for row in log:
@@ -56,6 +58,7 @@ def to_percent(y, position):
         return s + '%'
 
 def build_graph(data):
+    logging.debug('building graph')
     # create vectorized converter (can take list-like objects as
     # arguments)
     dateconv = np.vectorize(datetime.datetime.fromtimestamp)
@@ -128,6 +131,7 @@ if __name__ == "__main__":
 
     # actual energy at which the battery is considered dead
     # we compute the mean design capacity, then take the given percentage out of that
+    logging.debug('guessing expiry')
     zero = args.death * np.mean(data['energy_full_design']) / 100
     death = guess_expiry(data['energy_full'], data['timestamp'], zero)
     logging.info("this battery will reach end of life (%s%%) in %s, on %s",

--- a/battery-status-graph.py
+++ b/battery-status-graph.py
@@ -41,9 +41,13 @@ def parse_csv(fields = ['timestamp', 'energy_full', 'energy_full_design', 'energ
     logging.debug('loading CSV file %s with builtin CSV module', args.logfile)
     log = csv.DictReader(args.logfile)
     data = []
-    for row in log:
-        l = tuple([ row[f] for f in fields ])
-        data.append(l)
+    try:
+        for row in log:
+            l = tuple([ row[f] for f in fields ])
+            data.append(l)
+    except csv.Error as e:
+        logging.warning('CSV file is corrupt, skipping remaining entries: %s', e)
+    logging.debug('building data array')
     return np.array(data, dtype=zip(fields, 'f'*len(fields)))
 
 def to_percent(y, position):


### PR DESCRIPTION
this PR adds a quick fix to handle errors in CSV files, adds more information about the CSV parser i forgot about and debugging info.

turns out that out of battery laptop crashes can corrupt the logfile, inserting null bytes in there, which totally crashed the previous script. at least now we can parse the data before the corrupt data and display it. the user is expected to recover on its own.
